### PR TITLE
이메일 인증 로직 완성

### DIFF
--- a/server/src/main/java/com/example/goose/common/scheduler/VerificationCleanupTask.java
+++ b/server/src/main/java/com/example/goose/common/scheduler/VerificationCleanupTask.java
@@ -25,4 +25,16 @@ public class VerificationCleanupTask {
 
         authMapper.deleteExpiredUsers(calendar.getTime());
     }
+
+    @Scheduled(cron = "0 * * * * ?")
+    public void cleanupExpiredVerifiedUsers() {
+        Date now = new Date();
+
+        Calendar calendar = Calendar.getInstance();
+        calendar.setTime(now);
+        calendar.add(Calendar.MINUTE, -30);
+
+        authMapper.deleteExpiredUsers(calendar.getTime());
+    }
+
 }

--- a/server/src/main/java/com/example/goose/iGoose/auth/controller/AuthController.java
+++ b/server/src/main/java/com/example/goose/iGoose/auth/controller/AuthController.java
@@ -82,7 +82,7 @@ public class AuthController {
     public ResponseEntity<?> verifyEmail(@RequestBody VerificationRequest verificationRequest) throws Exception {
 
         try {
-            authService.verifyEmail(verificationRequest.getMethod(), verificationRequest.getCode());
+            authService.verifyEmail(verificationRequest);
             return ResponseEntity.ok("이메일 인증 성공");
         } catch (Exception e) {
             return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(e.getMessage());

--- a/server/src/main/java/com/example/goose/iGoose/auth/response/VerificationResponse.java
+++ b/server/src/main/java/com/example/goose/iGoose/auth/response/VerificationResponse.java
@@ -15,5 +15,6 @@ public class VerificationResponse {
     private String uuid;
     private String method;
     private Date expire;
+    private Boolean is_verified;
     private String code;
 }

--- a/server/src/main/java/com/example/goose/iGoose/auth/service/AuthService.java
+++ b/server/src/main/java/com/example/goose/iGoose/auth/service/AuthService.java
@@ -2,17 +2,21 @@ package com.example.goose.iGoose.auth.service;
 
 import com.example.goose.common.jwt.JwtTokenProvider;
 import com.example.goose.common.service.RefreshTokenService;
+import com.example.goose.iGoose.auth.request.VerificationRequest;
 import com.example.goose.iGoose.auth.response.VerificationResponse;
 import com.example.goose.iGoose.auth.request.LoginRequest;
 import com.example.goose.iGoose.auth.mapper.AuthMapper;
 import com.example.goose.iGoose.auth.vo.UserVO;
+import com.example.goose.iGoose.auth.vo.VerificationVO;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.mail.SimpleMailMessage;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+
 import java.util.Random;
 import java.util.Date;
 
@@ -31,20 +35,22 @@ public class AuthService {
     private final JavaMailSender mailSender;
 
 
-
-
     // ID 중복 체크
-    /** ID가 존재하면 true값 반환 */
+
+    /**
+     * ID가 존재하면 true값 반환
+     */
     public boolean isIdDuplicate(UserVO userVO) {
         return authMapper.countById(userVO.getId()) > 5;
     }
 
     /**
-     *  중복된 이메일이 존재하면 true 값 반환
-     * */
+     * 중복된 이메일이 존재하면 true 값 반환
+     */
     public boolean isEmailDuplicate(VerificationResponse verificationResponse) {
-        return authMapper.countByEmail(verificationResponse.getEmail()) > 5;
+        return authMapper.countByEmail(verificationResponse.getMethod()) > 5;
     }
+
     // 회원가입 로직
     public ResponseEntity<?> signup(UserVO userVO) throws Exception {
         String verificationCode = generateVerificationCode();
@@ -59,47 +65,76 @@ public class AuthService {
 
     /**
      * 이메일 발송 로직
-     * @param verificationResponse
+     * @param verificationRequest
      * @return
      * @throws Exception
      */
-    public ResponseEntity<?> sendEmail(VerificationResponse verificationResponse) throws Exception {
+    public ResponseEntity<?> sendEmail(VerificationRequest verificationRequest) throws Exception {
         String verificationCode = generateVerificationCode();
+        VerificationVO response = new VerificationVO();
 
-        verificationResponse.setUuid(UUID.randomUUID().toString());
-        verificationResponse.setEmail(verificationResponse.getEmail());
-        verificationResponse.setEmail_verification(verificationCode);
-        verificationResponse.setIs_verified(false);
-        sendVerificationEmail(verificationResponse.getEmail(), verificationResponse.getEmail_verification());
+        VerificationVO existingRecord = authMapper.findByMethod(verificationRequest.getMethod());
 
-        authMapper.emailVerification(verificationResponse);
 
-        return ResponseEntity.ok("이메일 발송 완료!");
+        if (existingRecord == null) {
+            response.setUuid(UUID.randomUUID().toString());
+            response.setMethod(verificationRequest.getMethod());
+            response.setCode(verificationCode);
+            response.setIs_verified(false);
+
+
+            sendVerificationEmail(verificationRequest.getMethod(), verificationCode);
+
+            authMapper.emailVerification(response);
+
+            return ResponseEntity.ok("첫 인증 메일 발송 완료");
+
+        }
+        existingRecord.setCode(verificationCode);
+        authMapper.updateVerificationCode(existingRecord);
+
+        sendVerificationEmail(verificationRequest.getMethod(), verificationCode);
+
+        return ResponseEntity.ok("인증 메일 재전송 성공");
     }
 
+    /**
+     * 랜덤 코드 생성
+     *
+     * @return
+     */
     private String generateVerificationCode() {
         return String.format("%06d", new Random().nextInt(999999));
     }
 
-    public void verifyEmail(String email, String code) throws Exception {
-        VerificationResponse verificationResponse = authMapper.findByEmail(email);
-        if (verificationResponse == null) {
-            throw new Exception("신규 유저.");
+    /**
+     * 이메일 인증 검사
+     *
+     * @param verificationRequest
+     * @throws Exception
+     */
+    public void verifyEmail(VerificationRequest verificationRequest) throws Exception {
+        VerificationVO verificationVO = authMapper.findByMethod(verificationRequest.getMethod());
+        if (verificationVO == null) {
+            throw new Exception("이메일 다름");
         }
 
-        if (!verificationResponse.getCode().equals(code)) {
+        if (!verificationRequest.getCode().equals(verificationVO.getCode())) {
             throw new Exception("코드가 일치하지 않습니다.");
         }
-
         Date now = new Date();
-        long diff = now.getTime() - verificationResponse.getExpire().getTime();
+        long diff = now.getTime() - verificationVO.getExpire().getTime();
         long minutes = TimeUnit.MILLISECONDS.toMinutes(diff);
 
         if (minutes > 3) {
             throw new Exception("만료된 코드 입니다.");
         }
-        verificationResponse.setExpire(null);
-        authMapper.updateEmailVerified(verificationResponse);
+
+        if (verificationVO.getIs_verified()) {
+            authMapper.deleteVerification(verificationVO.getUuid());
+        }
+
+        authMapper.updateEmailVerified(verificationVO.getUuid());
 
 
     }
@@ -122,7 +157,7 @@ public class AuthService {
             // uuid와 refreshToken, 만료 기간 저장
 
             return ResponseEntity.ok()
-                    .header("Authorization",  encryptedToken)
+                    .header("Authorization", encryptedToken)
                     .body("로그인 성공");
         } else {
             return ResponseEntity.status(401).body("로그인 실패");
@@ -132,7 +167,7 @@ public class AuthService {
     // 로그아웃 로직
     public void logout(String refreshToken) throws Exception {
 
-        if(!jwtTokenProvider.validateToken(refreshToken)) {
+        if (!jwtTokenProvider.validateToken(refreshToken)) {
             throw new Exception("유효하지 않은 refreshToken");
         }
 
@@ -148,9 +183,13 @@ public class AuthService {
     }
 
 
-
-    // email 인증 메일 전송 로직
-    public void sendVerificationEmail(String email, String verification){
+    /**
+     * 인증 메일 전송 로직
+     *
+     * @param email
+     * @param verification
+     */
+    public void sendVerificationEmail(String email, String verification) {
         if (email == null || !email.contains("@")) {
             throw new IllegalArgumentException("Invalid email address: " + email);
         }

--- a/server/src/main/java/com/example/goose/iGoose/auth/vo/VerificationVO.java
+++ b/server/src/main/java/com/example/goose/iGoose/auth/vo/VerificationVO.java
@@ -1,0 +1,24 @@
+package com.example.goose.iGoose.auth.vo;
+
+
+import lombok.*;
+
+import java.util.Date;
+
+@Getter
+@Setter
+@ToString
+@AllArgsConstructor
+@NoArgsConstructor
+public class VerificationVO {
+
+    private String uuid;
+
+    private String method;
+
+    private String code;
+
+    private Date expire;
+
+    private Boolean is_verified;
+}


### PR DESCRIPTION
🔈<log>: #9 이메일 인증 로직 추가
첫 이메일 인증과 두번째 인증을 구분하기 위해 verification 테이블에 is_verified 컬럼 추가
첫 인증을 완료하면 true값으로 변하고 두번째 인증을 완료하면 관련 데이터가 삭제되고 회원가입이 완료됨